### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         release-name: ["rc", "beta"]
     steps:


### PR DESCRIPTION
Bug fix: docker image being posted with the actual tag but not the network tag.

ie 1.9.0-beta.2 is upgraded and published from 1.9.0-beta.1 but the image 'beta' is not published

Solution: Add 'fail-fast : false' to the matrix 

This is to prevent the build from being cancelled and stopping the flow with the error ##[error]The operation was canceled. 

https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast